### PR TITLE
Add `rake` as test dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :test do
   gem 'codecov', require: false
+  gem 'rake'
   gem 'rspec'
 end
 


### PR DESCRIPTION
Without it it cause error:
```
can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
```