### PR TITLE
Replace word for Italian in spec

### DIFF
--- a/spec/detect_language_spec.rb
+++ b/spec/detect_language_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe OnlyofficeLanguageHelper::Detect_Language do
   end
 
   it 'check word for language' do
-    expect(OnlyofficeLanguageHelper::Detect_Language.detect_language('dall').first['language']).to eq('it')
+    expect(OnlyofficeLanguageHelper::Detect_Language.detect_language('Buongiorno').first['language']).to eq('it')
   end
 end


### PR DESCRIPTION
It started to fail and show `da` language
Just replace it, seems old word is pretty easy
and can be in any language